### PR TITLE
Remove getos fork and move to official release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1930,8 +1930,9 @@
       "dev": true
     },
     "getos": {
-      "version": "github:fwal/getos#3f36805be2805cd8f22913204cadd6ba2bcdf9e7",
-      "from": "github:fwal/getos#fix/package-support",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
+      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
       "requires": {
         "async": "^3.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@actions/exec": "^1.0.4",
     "@actions/io": "^1.0.2",
     "@actions/tool-cache": "^1.3.5",
-    "getos": "github:fwal/getos#fix/package-support",
+    "getos": "^3.2.1",
     "semver": "^7.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Can use official release as https://github.com/retrohacker/getos/pull/106 is merged 🎉 