### PR TITLE
Fix error output on Linux

### DIFF
--- a/__tests__/get-version.test.ts
+++ b/__tests__/get-version.test.ts
@@ -22,4 +22,11 @@ Target: x86_64-apple-macosx11.0`
     );
     expect(version).toBe("5.5");
   });
+
+  it("identifies version from swift version on linux", async () => {
+    const version = versionFromString(
+      "Swift version 5.5.1 (swift-5.5.1-RELEASE)"
+    );
+    expect(version).toBe("5.5.1");
+  });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -2751,7 +2751,7 @@ function run() {
                 core.setOutput("version", version);
             }
             else {
-                core.error("Failed to setup requested swift version");
+                core.error(`Failed to setup requested swift version. requestd: ${version}, actual: ${current}`);
             }
         }
         catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13725,7 +13725,7 @@ function getVersion(command = "swift", args = ["--version"]) {
 }
 exports.getVersion = getVersion;
 function versionFromString(subject) {
-    const match = subject.match(/Apple\ Swift\ version (?<version>[0-9]+\.[0-9+]+(\.[0-9]+)?)/) || {
+    const match = subject.match(/Swift\ version (?<version>[0-9]+\.[0-9+]+(\.[0-9]+)?)/) || {
         groups: { version: null },
     };
     if (!match.groups || !match.groups.version) {

--- a/src/get-version.ts
+++ b/src/get-version.ts
@@ -29,7 +29,7 @@ export async function getVersion(
 
 export function versionFromString(subject: string): string | null {
   const match = subject.match(
-    /Apple\ Swift\ version (?<version>[0-9]+\.[0-9+]+(\.[0-9]+)?)/
+    /Swift\ version (?<version>[0-9]+\.[0-9+]+(\.[0-9]+)?)/
   ) || {
     groups: { version: null },
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function run() {
     if (current === version) {
       core.setOutput("version", version);
     } else {
-      core.error("Failed to setup requested swift version");
+      core.error(`Failed to setup requested swift version. requestd: ${version}, actual: ${current}`);
     }
   } catch (error) {
     let dump: String;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,9 @@ async function run() {
     if (current === version) {
       core.setOutput("version", version);
     } else {
-      core.error(`Failed to setup requested swift version. requestd: ${version}, actual: ${current}`);
+      core.error(
+        `Failed to setup requested swift version. requestd: ${version}, actual: ${current}`
+      );
     }
   } catch (error) {
     let dump: String;


### PR DESCRIPTION
## Motivation

On linux, this action makes an error log every time.

example:  https://github.com/fwal/setup-swift/actions/runs/1506129234

> Integrate Swift 5.5 on ubuntu-latest
> Failed to setup requested swift version

I want to calm down the error logs.

## Reason

`getVersion` function anytime returns `null`on linux .
The regex searches `Apple Swift version`.

https://github.com/fwal/setup-swift/blob/a94947b51dc16f23683cbdded9b5313f716b04b9/src/get-version.ts#L32

But the output of `swift --verion` on Linux does not contains `Apple` keyword.

macOS: 

```
$ swift --version     
swift-driver version: 1.26.9 Apple Swift version 5.5.1 (swiftlang-1300.0.31.4 clang-1300.0.29.6)
Target: x86_64-apple-macosx12.0
```

Linux(running on docker for mac):

```
$ docker run -it --rm swift:5.5 /usr/bin/swift --version
Swift version 5.5.1 (swift-5.5.1-RELEASE)
Target: x86_64-unknown-linux-gnu
```

## How to fixed

just removed `Apple` keyword from the regex.