### PR TITLE
Run build to include new Swift version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8024,6 +8024,7 @@ const semver = __importStar(__webpack_require__(876));
 const core = __importStar(__webpack_require__(470));
 const os_1 = __webpack_require__(316);
 const VERSIONS_LIST = [
+    ["5.5.3", [os_1.OS.MacOS, os_1.OS.Ubuntu]],
     ["5.5.2", [os_1.OS.MacOS, os_1.OS.Ubuntu]],
     ["5.5.1", [os_1.OS.MacOS, os_1.OS.Ubuntu]],
     ["5.5", [os_1.OS.MacOS, os_1.OS.Ubuntu]],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-swift",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Set up GitHub Actions workflow with Swift support",
   "private": true,
   "main": "lib/main.js",


### PR DESCRIPTION
Run `npm run all`

It seems like with version 1.13.0 the dist folder was not updated, and thus the script fails to find Swift `5.5.3`. - I also bumped the version to 1.13.1, so it is ready for release

Fixes #366